### PR TITLE
Add custom instructions to chatWithScript and fetchPostGameMessage functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ To interact with Firebase, initialize your Firebase project and replace the Fire
 6. Users can view their game history on the history page.
 
 
+## GPT Game Engine
+
 ## GPT Usage caps
 
 
@@ -71,6 +73,3 @@ To interact with Firebase, initialize your Firebase project and replace the Fire
 
 
 ## Commands (future build)
-
-
-## 

--- a/TASKS.md
+++ b/TASKS.md
@@ -85,12 +85,12 @@ DecodeMe! is a web-based game that helps players understand code snippets in a f
 - [x] Create share game component with copy to clipboard link
 - [x] Implement Dynamic SEO
 - [x] Implement User Stats page
-- [ ] Implement custom instructions
+- [x] Implement GPT usage cap or rate limits
+- [x] Implement custom instructions
 - [ ] Implement AI commands
   - [ ] /Instruct
   - [ ] /Help
   - [ ] /Remember
-- [x] Implement GPT usage cap or rate limits
 - [ ] Implement account upgrade option
 
 ### Future Release Features
@@ -128,6 +128,7 @@ DecodeMe! is a web-based game that helps players understand code snippets in a f
 ### Testing
 - [ ] Test anonymous user flow
 - [ ] UI tests for frontend
+- [ ] Test sign up flow
 
 ### Deployment
 - [x] Deploy backend to cloud provider

--- a/pages/assistantSettings/[userId].js
+++ b/pages/assistantSettings/[userId].js
@@ -1,14 +1,14 @@
 // pages/assistantSettings/[userId].js
 import { useState } from 'react';
 import { useRouter } from 'next/router';
-import { getFirebaseFirestore } from '../../app/src/firebase'; // Updated import
+import { getFirebaseFirestore } from '../../app/src/firebase';
 import RootLayout from '../../components/layout';
-import NavigationButtons from '../../components/NavigationButtons'; // New import
+import NavigationButtons from '../../components/NavigationButtons';
 import { Button, Textarea } from '@nextui-org/react';
 import { db as dbServer } from '../../firebaseAdmin'; // Server-side db
 import { doc, updateDoc } from 'firebase/firestore';
 import { useAuth } from '../../contexts/AuthContext'; // New import
-import { toast } from 'react-hot-toast'; // New import
+import { toast } from 'react-hot-toast';
 
 // This constant defines the maximum character limit for the textareas
 const MAX_CHAR_LIMIT = 90;
@@ -63,9 +63,9 @@ const AssistantSettingsPage = ({ userData }) => {
               <div className="input-group" style={{ marginBottom: '15px' }}>
                 <Textarea
                   id="codeGen"
-                  label="Code Generation Instructions:"
+                  label="Gameplay:"
                   variant="bordered"
-                  placeholder="Enter your code generation instructions"
+                  placeholder="Example: I like short scripts"
                   value={customInstructions.codeGen}
                   onValueChange={(value) => handleInputChange('codeGen', { target: { value } })}
                   disableAnimation
@@ -80,12 +80,12 @@ const AssistantSettingsPage = ({ userData }) => {
                   helperColor={customInstructions.codeGen.length > MAX_CHAR_LIMIT ? "error" : "default"}
                 />
               </div>
-              {/* <div className="input-group" style={{ marginBottom: '15px' }}>
+              <div className="input-group" style={{ marginBottom: '15px' }}>
                 <Textarea
                   id="chatbot"
-                  label="Chatbot Instructions:"
+                  label="Assistant Behavior:"
                   variant="bordered"
-                  placeholder="Enter your chatbot instructions"
+                  placeholder="Example: I like direct responses"
                   value={customInstructions.chatbot}
                   onValueChange={(value) => handleInputChange('chatbot', { target: { value } })}
                   disableAnimation
@@ -98,15 +98,15 @@ const AssistantSettingsPage = ({ userData }) => {
                   maxLength={MAX_CHAR_LIMIT}
                   helperText={customInstructions.chatbot.length > MAX_CHAR_LIMIT ? "Maximum character limit of " + MAX_CHAR_LIMIT + " exceeded." : ""}
                   helperColor={customInstructions.chatbot.length > MAX_CHAR_LIMIT ? "error" : "default"}
-                  disabled
                 />
               </div>
+              {/* 
               <div className="input-group" style={{ marginBottom: '20px' }}>
                 <Textarea
                   id="endGame"
                   label="End Game Message Instructions:"
                   variant="bordered"
-                  placeholder="Enter your end game message instructions"
+                  placeholder="Example: "
                   value={customInstructions.endGame}
                   onValueChange={(value) => handleInputChange('endGame', { target: { value } })}
                   disableAnimation


### PR DESCRIPTION
This commit includes changes to the chatWithScript and fetchPostGameMessage functions to incorporate user-specific custom instructions. The custom instructions are fetched from Firestore based on the user's ID and appended to the system message sent to the OpenAI API. This allows the AI's response to be tailored according to the user's custom instructions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the "GPT Game Engine" section in `README.md`.
  - Modified the "GPT Usage caps" section and removed outdated sections in `README.md`.
  - Marked "Implement custom instructions" and "Implement GPT usage cap or rate limits" tasks as complete in `TASKS.md`.
  - Added "Test sign up flow" as an incomplete task in `TASKS.md`.

- **New Features**
  - Chatbot now retrieves and uses custom instructions from Firestore, enhancing personalized interactions.

- **Refactor**
  - Improved user settings page with clearer labels and cleaner code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->