### PR TITLE
Add codegen and chat instructions to CustomInstructions popover

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -88,7 +88,7 @@ DecodeMe! is a web-based game that helps players understand code snippets in a f
 - [x] Custom instruction guardrails
 - [x] Leadeboard name generator
 - [x] Integrate Google Analytics
-- [ ] "Play more like this" functionality
+- [x] "Play more like this" functionality
 - [ ] Implement AI commands
   - [ ] /Instruct
   - [ ] /Help
@@ -142,6 +142,7 @@ DecodeMe! is a web-based game that helps players understand code snippets in a f
 - [x] Leaderboard should have tooltip or something for truncated long names
 - [x] Add Play Again button to gameover
 - [x] Finalize post game review system and user messages
+- [ ] Add a routing loading icon in the bottom right for routes to SSR pages
  
 ### Testing
 - [ ] Test anonymous user flow

--- a/components/CustomInstructionsIndicator.js
+++ b/components/CustomInstructionsIndicator.js
@@ -1,0 +1,20 @@
+// Path: components/CustomInstructionsIndicator.js
+
+import { Badge } from '@nextui-org/react';
+import React from 'react';
+
+const CustomInstructionsIndicator = () => {
+  const playSimilar = localStorage.getItem('playSimilar') === 'true';
+
+  if (!playSimilar) {
+    return null; // Don't display the component if not in 'Play Similar' mode
+  }
+
+  return (
+    <Badge color="primary" variant="dot">
+      Custom Instructions Enabled
+    </Badge>
+  );
+};
+
+export default CustomInstructionsIndicator;

--- a/components/CustomInstructionsIndicator.js
+++ b/components/CustomInstructionsIndicator.js
@@ -1,7 +1,8 @@
 import { Popover, PopoverTrigger, PopoverContent, Chip } from '@nextui-org/react';
 import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
 
-const CustomInstructionsIndicator = () => {
+const CustomInstructionsIndicator = ({ customInstructions }) => {
   const [visible, setVisible] = useState(false);
   const [playSimilar, setPlaySimilar] = useState(false);
   const [selectedScript, setSelectedScript] = useState(null);
@@ -34,12 +35,32 @@ const CustomInstructionsIndicator = () => {
     return code?.replace(/```python\n|```python|```/g, '').trim() || '';
   };
 
-  if (!playSimilar || !selectedScript) {
+  // Determine if there are any custom instructions for codegen or chat
+  const hasCustomInstructions = customInstructions.codeGen || customInstructions.chatbot;
+
+  // Adjust the condition to render the chip if playSimilar is true or if there are custom instructions
+  if (!playSimilar && !hasCustomInstructions) {
     return null;
   }
 
-  // Use the formatCodeSnippet function to format the selectedScript.question
-  const formattedCode = formatCodeSnippet(selectedScript.question);
+  // Use the formatCodeSnippet function to format the selectedScript.question if selectedScript is not null
+  const formattedCode = selectedScript ? formatCodeSnippet(selectedScript.question) : '';
+
+  // Use the existing formatCodeSnippet function to format the custom instructions for codegen and chat
+  const formattedCodegenInstructions = formatCodeSnippet(customInstructions.codeGen);
+  const formattedChatInstructions = formatCodeSnippet(customInstructions.chatbot);
+
+  // Define a common style for both sections
+  const commonPreStyle = {
+    background: '#f6f8fa',
+    padding: '1rem',
+    borderRadius: '6px',
+    maxWidth: '250px', // Ensure the code block does not exceed this width
+    whiteSpace: 'pre-wrap',
+    wordBreak: 'break-word',
+    fontSize: '0.875rem',
+    margin: '0', // Ensure there's no default margin
+  };
 
   return (
     <Popover isOpen={visible} onOpenChange={setVisible} placement="right" showArrow={true}>
@@ -55,34 +76,56 @@ const CustomInstructionsIndicator = () => {
       </PopoverTrigger>
       <PopoverContent css={{ maxWidth: '300px' }}>
         <div style={{ padding: '1rem' }}>
-          <strong style={{ fontSize: '1rem' }}>Active Instructions</strong>
-          <h5 style={{
-            maxWidth: '250px', // Set a max-width for the header
-            wordBreak: 'break-word' // Break words at the end of the line
+          <strong style={{
+            fontSize: '1.25rem', // Increased font size
+            fontWeight: '600', // Increased font weight for emphasis
+            marginBottom: '0.5rem', // Added bottom margin for spacing
+            display: 'block' // Ensure it's on its own line
           }}>
-            The user has requested to use this code snippet as an example:
-          </h5>
-          {formattedCode ? (
-            <div style={{ maxHeight: '100px', overflowY: 'auto' }}>
-              <pre style={{
-                background: '#f6f8fa',
-                padding: '0.5rem',
-                borderRadius: '6px',
-                maxWidth: '250px', // Ensure the code block does not exceed this width
-                whiteSpace: 'pre-wrap',
-                wordBreak: 'break-word',
-                fontSize: '0.875rem'
+            Active Instructions
+          </strong>
+          {playSimilar && formattedCode && (
+            <>
+              <h5 style={{
+                maxWidth: '250px', // Set a max-width for the header
+                wordBreak: 'break-word' // Break words at the end of the line
               }}>
-                <code>{formattedCode}</code>
+                The user has requested to use this code snippet as an example:
+              </h5>
+              <div style={{ maxHeight: '100px', overflowY: 'auto', marginBottom: '1rem' }}>
+                <pre style={commonPreStyle}>
+                  <code>{formattedCode}</code>
+                </pre>
+              </div>
+            </>
+          )}
+          {formattedCodegenInstructions && (
+            <div style={{ marginBottom: '1rem' }}>
+              <strong style={{ fontSize: '1rem' }}>Gameplay Instructions</strong>
+              <pre style={commonPreStyle}>
+                <code>{formattedCodegenInstructions}</code>
               </pre>
             </div>
-          ) : (
-            <p>No custom instructions found.</p>
+          )}
+          {formattedChatInstructions && (
+            <div>
+              <strong style={{ fontSize: '1rem' }}>Assistant Instructions</strong>
+              <pre style={commonPreStyle}>
+                <code>{formattedChatInstructions}</code>
+              </pre>
+            </div>
           )}
         </div>
       </PopoverContent>
     </Popover>
   );
+};
+
+CustomInstructionsIndicator.propTypes = {
+  customInstructions: PropTypes.shape({
+    codeGen: PropTypes.string,
+    chatbot: PropTypes.string,
+  }),
 };
 
 export default CustomInstructionsIndicator;

--- a/components/CustomInstructionsIndicator.js
+++ b/components/CustomInstructionsIndicator.js
@@ -1,19 +1,61 @@
-// Path: components/CustomInstructionsIndicator.js
-
-import { Badge } from '@nextui-org/react';
-import React from 'react';
+import { Popover, PopoverTrigger, PopoverContent, Chip } from '@nextui-org/react';
+import React, { useState, useEffect } from 'react';
 
 const CustomInstructionsIndicator = () => {
-  const playSimilar = localStorage.getItem('playSimilar') === 'true';
+  const [visible, setVisible] = useState(false);
+  const [playSimilar, setPlaySimilar] = useState(false);
+  const [selectedScript, setSelectedScript] = useState(null);
 
-  if (!playSimilar) {
-    return null; // Don't display the component if not in 'Play Similar' mode
+  useEffect(() => {
+    // Access localStorage only on the client-side
+    if (typeof window !== 'undefined') {
+      const playSimilarValue = localStorage.getItem('playSimilar') === 'true';
+      const script = localStorage.getItem('selectedScriptForSimilarGame');
+      setPlaySimilar(playSimilarValue);
+      setSelectedScript(script ? JSON.parse(script) : null);
+    }
+  }, []);
+
+  if (!playSimilar || !selectedScript) {
+    return null;
   }
 
   return (
-    <Badge color="primary" variant="dot">
-      Custom Instructions Enabled
-    </Badge>
+    <Popover isOpen={visible} onOpenChange={setVisible} placement="right" showArrow={true}>
+      <PopoverTrigger>
+        <Chip
+          variant="flat"
+          color="primary"
+          onClick={() => setVisible(true)}
+          css={{ cursor: 'pointer', ':hover': { opacity: 0.8 } }}
+        >
+          Custom Instructions
+        </Chip>
+      </PopoverTrigger>
+      <PopoverContent css={{ maxWidth: '300px' }}>
+        <div style={{ padding: '1rem' }}>
+          <strong style={{ fontSize: '1rem' }}>Active Instructions</strong>
+          <h5>The user has requested to use this code snippet as an example:</h5>
+          {selectedScript.question ? (
+            <div style={{ maxHeight: '100px', overflowY: 'auto' }}>
+              <pre style={{
+                background: '#f6f8fa',
+                padding: '0.5rem',
+                borderRadius: '6px',
+                maxWidth: '250px', // Set a max-width for the code block
+                whiteSpace: 'pre-wrap', // Allow text to wrap
+                wordBreak: 'break-word', // Break words at the end of the line
+                fontSize: '0.875rem'
+              }}>
+                <code>{selectedScript.question}</code>
+              </pre>
+            </div>
+          ) : (
+            <p>No custom instructions found.</p>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
   );
 };
 

--- a/components/CustomInstructionsIndicator.js
+++ b/components/CustomInstructionsIndicator.js
@@ -16,9 +16,30 @@ const CustomInstructionsIndicator = () => {
     }
   }, []);
 
+  useEffect(() => {
+    const handleStorageCleared = () => {
+      setPlaySimilar(false);
+      setSelectedScript(null);
+    };
+
+    window.addEventListener('storageCleared', handleStorageCleared);
+
+    return () => {
+      window.removeEventListener('storageCleared', handleStorageCleared);
+    };
+  }, []);
+
+  // Function to format the code snippet
+  const formatCodeSnippet = (code) => {
+    return code?.replace(/```python\n|```python|```/g, '').trim() || '';
+  };
+
   if (!playSimilar || !selectedScript) {
     return null;
   }
+
+  // Use the formatCodeSnippet function to format the selectedScript.question
+  const formattedCode = formatCodeSnippet(selectedScript.question);
 
   return (
     <Popover isOpen={visible} onOpenChange={setVisible} placement="right" showArrow={true}>
@@ -35,19 +56,24 @@ const CustomInstructionsIndicator = () => {
       <PopoverContent css={{ maxWidth: '300px' }}>
         <div style={{ padding: '1rem' }}>
           <strong style={{ fontSize: '1rem' }}>Active Instructions</strong>
-          <h5>The user has requested to use this code snippet as an example:</h5>
-          {selectedScript.question ? (
+          <h5 style={{
+            maxWidth: '250px', // Set a max-width for the header
+            wordBreak: 'break-word' // Break words at the end of the line
+          }}>
+            The user has requested to use this code snippet as an example:
+          </h5>
+          {formattedCode ? (
             <div style={{ maxHeight: '100px', overflowY: 'auto' }}>
               <pre style={{
                 background: '#f6f8fa',
                 padding: '0.5rem',
                 borderRadius: '6px',
-                maxWidth: '250px', // Set a max-width for the code block
-                whiteSpace: 'pre-wrap', // Allow text to wrap
-                wordBreak: 'break-word', // Break words at the end of the line
+                maxWidth: '250px', // Ensure the code block does not exceed this width
+                whiteSpace: 'pre-wrap',
+                wordBreak: 'break-word',
                 fontSize: '0.875rem'
               }}>
-                <code>{selectedScript.question}</code>
+                <code>{formattedCode}</code>
               </pre>
             </div>
           ) : (

--- a/pages/index.js
+++ b/pages/index.js
@@ -399,7 +399,9 @@ useEffect(() => {
               </div>
               {score}
             </div>
-            <CustomInstructionsIndicator />
+            <div className="absolute top-0 right-10 p-4">
+          <CustomInstructionsIndicator />
+        </div>
             {gameMode && <div className="flex justify-center"><StrikeIndicator strikes={strikes} limit={strikeLimit} /></div>}
           </h1>
           <div className="auth-container" style={isAuthLoading || !user ? { display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' } : {}}>

--- a/pages/index.js
+++ b/pages/index.js
@@ -401,7 +401,7 @@ useEffect(() => {
               {score}
             </div>
             <div className="absolute top-0 right-10 p-4">
-          <CustomInstructionsIndicator />
+            <CustomInstructionsIndicator customInstructions={customInstructions} />
         </div>
             {gameMode && <div className="flex justify-center"><StrikeIndicator strikes={strikes} limit={strikeLimit} /></div>}
           </h1>

--- a/pages/index.js
+++ b/pages/index.js
@@ -22,6 +22,7 @@ import { useSoundContext } from '../contexts/SoundContext';
 import { useGame } from '../contexts/GameContext';
 import usePlaySimilar from '../hooks/usePlaySimilar';
 import { useRouter } from 'next/router';
+import CustomInstructionsIndicator from '../components/CustomInstructionsIndicator';
 
 export default function Home() {
   const { user, loading: isAuthLoading, setUser } = useAuth();
@@ -398,6 +399,7 @@ useEffect(() => {
               </div>
               {score}
             </div>
+            <CustomInstructionsIndicator />
             {gameMode && <div className="flex justify-center"><StrikeIndicator strikes={strikes} limit={strikeLimit} /></div>}
           </h1>
           <div className="auth-container" style={isAuthLoading || !user ? { display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' } : {}}>

--- a/pages/index.js
+++ b/pages/index.js
@@ -233,9 +233,10 @@ export default function Home() {
       if (!keepLocalStorage) {
         localStorage.removeItem('selectedScriptForSimilarGame');
         localStorage.removeItem('playSimilar');
+        window.dispatchEvent(new Event('storageCleared'));
       }
     };
-  console.log('resetGame is a function:', typeof resetGame === 'function');
+
   const handlePlaySimilar = usePlaySimilar();
 
   const confirmEndGame = () => {
@@ -413,6 +414,7 @@ useEffect(() => {
                     selectedKey={learningLevel}
                     onSelectionChange={updateLearningLevelInFirebase}
                     className="flex justify-center"
+                    color="primary"
                   >
                     <Tab key="beginner" title="Beginner" />
                     <Tab key="intermediate" title="Regular" />


### PR DESCRIPTION
Add codegen and chat instructions to CustomInstructions popover

- Implement retrieval of playSimilar and selectedScript values from localStorage.
- Add useEffect hooks to listen for 'storageCleared' events and update state accordingly.
- Create formatCodeSnippet function to clean up and format code snippets for display.
- Introduce conditional rendering to display the Custom Instructions chip only when there are instructions or playSimilar is set.
- Format and display the selectedScript.question when playSimilar is true.
- Format and display customInstructions for codegen and chatbot.
- Adjust styling to ensure consistent spacing and clear section headers within the popover.
- Ensure that the component gracefully handles the absence of custom instructions.